### PR TITLE
Bugfix/Login attempt with Fiware throws Internal Server error

### DIFF
--- a/fiware_server.js
+++ b/fiware_server.js
@@ -63,10 +63,12 @@ OAuth.registerService('fiware', 2, null, function(query) {
    *  expiresAt, as a ms epochtime
    *  refreshToken, if there is one
    *  id - note that there *must* be an id property for Meteor to work with
+   *  username - this field is required during the first login attempt, equals the id in FIWARE
    */
   const serviceData = {
     accessToken,
-    expiresAt: (+new Date) + (1000 * response.expiresIn)
+    expiresAt: (+new Date) + (1000 * response.expiresIn),
+    username: identity.id
   };
   if (response.refreshToken) {
     serviceData.refreshToken = response.refreshToken;


### PR DESCRIPTION
WIP
Fixes Apinf bug [3209](https://github.com/apinf/platform/issues/3209)

Meteor is expecting service data to include a username field during the first login attempt.

When the field is not provided the value of result.error (AccountsServer.Ap._attemptLogin (packages/accounts-base/accounts_server.js) is not empty (Something like missing Username field)

That results on attempt.error being filled with result.error which causes a circular JSON error, which is why a 500 error is given (This seems to be a bug in the accounts_server.js)